### PR TITLE
fix missing normal bikes

### DIFF
--- a/src/citybikes/gbfs/versions/v2/types.py
+++ b/src/citybikes/gbfs/versions/v2/types.py
@@ -216,7 +216,7 @@ class Station2GbfsStationInfo(StationInfo):
 class Station2GbfsStationStatus(StationStatus):
     @staticmethod
     def vehicle_types(station):
-        counts = station.extra.vehicle_counts()
+        counts = station.stat.vehicle_counts()
 
         if not counts:
             return [VehicleCounts.Default(count=station.stat.bikes)]

--- a/src/citybikes/gbfs/versions/v3/types.py
+++ b/src/citybikes/gbfs/versions/v3/types.py
@@ -237,7 +237,7 @@ class Station2GbfsStationInfo(StationInfo):
 class Station2GbfsStationStatus(StationStatus):
     @staticmethod
     def vehicle_types(station):
-        counts = station.extra.vehicle_counts()
+        counts = station.stat.vehicle_counts()
 
         if not counts:
             return [VehicleCounts.Default(count=station.stat.bikes)]


### PR DESCRIPTION
not all pybikes feeds with 'ebikes' in extra contain 'normal_bikes'. In
that case the assumption is that normal_bikes = station.bikes - ebikes

Fix #3 